### PR TITLE
Feature/#28 - 산책 모집글 CRUD 및 목록 조회 API 적용

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,21 @@
 .idea/
 *.iml
 
+# Environment variables (frontend)
+.env
+
 # macOS system files
 .DS_Store
+
+# Eclipse / STS
+**/.project
+**/.settings/
+
+# VS Code
+**/.vscode/
+
+# OpenCode
+**/.opencode/
 
 # Build output
 /out/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-  "java.compile.nullAnalysis.mode": "automatic"
-}

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -42,3 +42,6 @@ out/
 .env.production
 *.env
 !.env.example
+
+### Local docs ### 
+/docs/

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -38,3 +38,7 @@ out/
 
 ### env ###
 .env
+.env.local
+.env.production
+*.env
+!.env.example

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -55,6 +55,19 @@ dependencies {
 }
 
 tasks.named('test') {
+	// Load non-sensitive values from gradle.properties
+	environment "MYSQL_PORT", project.hasProperty('MYSQL_PORT') ? project.MYSQL_PORT : '3307'
+	environment "REDIS_PORT", project.hasProperty('REDIS_PORT') ? project.REDIS_PORT : '6380'
+	environment "MYSQL_DATABASE", project.hasProperty('MYSQL_DATABASE') ? project.MYSQL_DATABASE : 'mongmate'
+	environment "MYSQL_USER", project.hasProperty('MYSQL_USER') ? project.MYSQL_USER : 'monguser'
+	
+	// Load sensitive values from system environment with defaults
+	environment "MYSQL_PASSWORD", System.getenv('MYSQL_PASSWORD') ?: 'test-password'
+	environment "JWT_SECRET_BASE64", System.getenv('JWT_SECRET_BASE64') ?: 'test-jwt-secret'
+	environment "SOLAPI_API_KEY", System.getenv('SOLAPI_API_KEY') ?: 'test-api-key'
+	environment "SOLAPI_API_SECRET", System.getenv('SOLAPI_API_SECRET') ?: 'test-api-secret'
+	environment "SOLAPI_FROM_NUMBER", System.getenv('SOLAPI_FROM_NUMBER') ?: '01012345678'
+	
 	useJUnitPlatform()
 }
 

--- a/backend/gradle.properties
+++ b/backend/gradle.properties
@@ -1,0 +1,19 @@
+# Gradle Properties for Mongmate Project
+# Non-sensitive configuration only (safe to commit)
+
+# Database Configuration
+MYSQL_MAJOR=8.3
+MYSQL_DATABASE=mongmate
+MYSQL_USER=monguser
+MYSQL_PORT=3307
+MYSQL_CONTAINER_NAME=mongmate-mysql
+
+# Redis Configuration  
+REDIS_PORT=6380
+REDIS_CONTAINER_NAME=mongmate-redis
+
+# Project Configuration
+COMPOSE_PROJECT_NAME=mongmate
+
+# Spring Boot Test Configuration
+SPRING_PROFILES_ACTIVE=test

--- a/backend/src/main/java/kr/co/mongmate/api/chat/controller/ChatRoomListController.java
+++ b/backend/src/main/java/kr/co/mongmate/api/chat/controller/ChatRoomListController.java
@@ -1,0 +1,27 @@
+package kr.co.mongmate.api.chat.controller;
+
+import kr.co.mongmate.api.chat.dto.ChatRoomListItemResponse;
+import kr.co.mongmate.api.chat.service.ChatRoomListService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.security.Principal;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/chat/rooms")
+public class ChatRoomListController {
+
+    private final ChatRoomListService chatRoomListService;
+
+    @GetMapping
+    public List<ChatRoomListItemResponse> loadMyRooms(Principal principal) {
+        if (principal == null || principal.getName() == null || principal.getName().isBlank()) {
+            throw new IllegalStateException("principal is required");
+        }
+        return chatRoomListService.loadMyRooms(principal.getName());
+    }
+}

--- a/backend/src/main/java/kr/co/mongmate/api/chat/dto/ChatRoomLastMessageDto.java
+++ b/backend/src/main/java/kr/co/mongmate/api/chat/dto/ChatRoomLastMessageDto.java
@@ -1,0 +1,10 @@
+package kr.co.mongmate.api.chat.dto;
+
+import java.time.LocalDateTime;
+
+public record ChatRoomLastMessageDto(
+        String senderId,
+        String content,
+        long seq,
+        LocalDateTime sentAt
+) {}

--- a/backend/src/main/java/kr/co/mongmate/api/chat/dto/ChatRoomListItemResponse.java
+++ b/backend/src/main/java/kr/co/mongmate/api/chat/dto/ChatRoomListItemResponse.java
@@ -1,0 +1,13 @@
+package kr.co.mongmate.api.chat.dto;
+
+import java.time.LocalDateTime;
+
+public record ChatRoomListItemResponse(
+        String roomId,
+        String title,
+        long currentSeq,
+        long lastReadSeq,
+        long unreadCount,
+        ChatRoomLastMessageDto lastMessage,
+        LocalDateTime updatedAt
+) {}

--- a/backend/src/main/java/kr/co/mongmate/api/chat/service/ChatRoomListService.java
+++ b/backend/src/main/java/kr/co/mongmate/api/chat/service/ChatRoomListService.java
@@ -1,0 +1,146 @@
+package kr.co.mongmate.api.chat.service;
+
+import kr.co.mongmate.api.chat.dto.ChatMessageDto;
+import kr.co.mongmate.api.chat.dto.ChatRoomLastMessageDto;
+import kr.co.mongmate.api.chat.dto.ChatRoomListItemResponse;
+import kr.co.mongmate.domain.chat.entity.ChatReadState;
+import kr.co.mongmate.domain.chat.entity.ChatThread;
+import kr.co.mongmate.domain.chat.repository.ChatReadStateRepository;
+import kr.co.mongmate.domain.profile.entity.GuardianProfile;
+import kr.co.mongmate.domain.profile.repository.GuardianProfileRepository;
+import kr.co.mongmate.infra.chat.service.ChatRedisService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.OptionalLong;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ChatRoomListService {
+
+    private final ChatReadStateRepository chatReadStateRepository;
+    private final GuardianProfileRepository guardianProfileRepository;
+    private final ChatRedisService chatRedisService;
+
+    public List<ChatRoomListItemResponse> loadMyRooms(String userId) {
+        Long uid = parseLongOrThrow(userId, "userId");
+
+        List<ChatReadState> states = chatReadStateRepository.findAllByUserIdWithThread(uid);
+        if (states.isEmpty()) {
+            return List.of();
+        }
+
+        Map<Long, String> nicknameByUserId = loadNicknames(states, uid);
+
+        List<ChatRoomListItemResponse> items = new ArrayList<>();
+        for (ChatReadState state : states) {
+            ChatThread thread = state.getChatThread();
+            String roomId = String.valueOf(thread.getId());
+
+            long currentSeq = chatRedisService.getCurrentSeq(roomId);
+            long lastReadSeq = resolveLastReadSeq(roomId, userId, currentSeq);
+            long unreadCount = Math.max(0, currentSeq - lastReadSeq);
+
+            ChatRoomLastMessageDto lastMessage = loadLastMessage(roomId);
+            LocalDateTime updatedAt = resolveUpdatedAt(thread, lastMessage);
+
+            Long counterpartId = resolveCounterpartId(thread, uid);
+            String title = resolveTitle(counterpartId, nicknameByUserId);
+
+            items.add(new ChatRoomListItemResponse(
+                    roomId,
+                    title,
+                    currentSeq,
+                    lastReadSeq,
+                    unreadCount,
+                    lastMessage,
+                    updatedAt
+            ));
+        }
+
+        items.sort(Comparator.comparing(ChatRoomListItemResponse::updatedAt,
+                Comparator.nullsLast(Comparator.reverseOrder())));
+
+        return items;
+    }
+
+    private Map<Long, String> loadNicknames(List<ChatReadState> states, Long myId) {
+        Set<Long> counterpartIds = states.stream()
+                .map(ChatReadState::getChatThread)
+                .map(thread -> resolveCounterpartId(thread, myId))
+                .collect(Collectors.toSet());
+
+        List<GuardianProfile> profiles = guardianProfileRepository.findAllByUserIdIn(counterpartIds);
+        return profiles.stream()
+                .collect(Collectors.toMap(GuardianProfile::getUserId, GuardianProfile::getNickname));
+    }
+
+    private Long resolveCounterpartId(ChatThread thread, Long myId) {
+        Long authorId = thread.getAuthor().getId();
+        if (Objects.equals(authorId, myId)) {
+            return thread.getParticipant().getId();
+        }
+        return authorId;
+    }
+
+    private String resolveTitle(Long counterpartId, Map<Long, String> nicknameByUserId) {
+        String nickname = nicknameByUserId.get(counterpartId);
+        if (nickname != null && !nickname.isBlank()) {
+            return nickname;
+        }
+        log.warn("Missing GuardianProfile nickname for userId={}", counterpartId);
+        return "알 수 없음";
+    }
+
+    private ChatRoomLastMessageDto loadLastMessage(String roomId) {
+        List<ChatMessageDto> messages = chatRedisService.loadRecent(roomId, 1);
+        if (messages.isEmpty()) {
+            return null;
+        }
+        ChatMessageDto last = messages.get(0);
+        return new ChatRoomLastMessageDto(
+                last.userId(),
+                last.content(),
+                last.seq(),
+                toLocalDateTime(last.timestamp())
+        );
+    }
+
+    private LocalDateTime resolveUpdatedAt(ChatThread thread, ChatRoomLastMessageDto lastMessage) {
+        if (lastMessage != null && lastMessage.sentAt() != null) {
+            return lastMessage.sentAt();
+        }
+        if (thread.getUpdatedAt() != null) {
+            return thread.getUpdatedAt();
+        }
+        return thread.getCreatedAt();
+    }
+
+    private LocalDateTime toLocalDateTime(long epochMillis) {
+        return LocalDateTime.ofInstant(Instant.ofEpochMilli(epochMillis), ZoneId.systemDefault());
+    }
+
+    private long resolveLastReadSeq(String roomId, String userId, long currentSeq) {
+        OptionalLong existing = chatRedisService.getLastReadSeqIfPresent(roomId, userId);
+        if (existing.isPresent()) {
+            return existing.getAsLong();
+        }
+        chatRedisService.setLastReadSeq(roomId, userId, currentSeq);
+        return currentSeq;
+    }
+
+    private Long parseLongOrThrow(String value, String field) {
+        try {
+            return Long.parseLong(value);
+        } catch (Exception e) {
+            throw new IllegalArgumentException(field + " must be a number: " + value);
+        }
+    }
+}

--- a/backend/src/main/java/kr/co/mongmate/api/walkpost/controller/WalkPostCreateController.java
+++ b/backend/src/main/java/kr/co/mongmate/api/walkpost/controller/WalkPostCreateController.java
@@ -1,0 +1,32 @@
+package kr.co.mongmate.api.walkpost.controller;
+
+import kr.co.mongmate.api.walkpost.dto.WalkPostCreateRequest;
+import kr.co.mongmate.api.walkpost.dto.WalkPostCreateResponse;
+import kr.co.mongmate.api.walkpost.service.WalkPostCreateService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.security.Principal;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/walk-posts")
+public class WalkPostCreateController {
+
+    private final WalkPostCreateService walkPostCreateService;
+
+    @PostMapping
+    public ResponseEntity<WalkPostCreateResponse> create(
+            @RequestBody WalkPostCreateRequest request,
+            Principal principal
+    ) {
+        String userId = principal != null ? principal.getName() : null;
+        WalkPostCreateResponse response = walkPostCreateService.create(userId, request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+}

--- a/backend/src/main/java/kr/co/mongmate/api/walkpost/controller/WalkPostDetailController.java
+++ b/backend/src/main/java/kr/co/mongmate/api/walkpost/controller/WalkPostDetailController.java
@@ -1,0 +1,22 @@
+package kr.co.mongmate.api.walkpost.controller;
+
+import kr.co.mongmate.api.walkpost.dto.WalkPostDetailResponse;
+import kr.co.mongmate.api.walkpost.service.WalkPostDetailService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/walk-posts")
+public class WalkPostDetailController {
+
+    private final WalkPostDetailService walkPostDetailService;
+
+    @GetMapping("/{postId}")
+    public WalkPostDetailResponse getDetail(@PathVariable Long postId) {
+        return walkPostDetailService.getDetail(postId);
+    }
+}

--- a/backend/src/main/java/kr/co/mongmate/api/walkpost/controller/WalkPostListController.java
+++ b/backend/src/main/java/kr/co/mongmate/api/walkpost/controller/WalkPostListController.java
@@ -1,0 +1,28 @@
+package kr.co.mongmate.api.walkpost.controller;
+
+import kr.co.mongmate.api.walkpost.dto.WalkPostListResponse;
+import kr.co.mongmate.api.walkpost.service.WalkPostListService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/walk-posts")
+public class WalkPostListController {
+
+    private final WalkPostListService walkPostListService;
+
+    @GetMapping
+    public WalkPostListResponse list(
+            @RequestParam(required = false) Integer page,
+            @RequestParam(required = false) Integer size,
+            @RequestParam(required = false) Long regionId,
+            @RequestParam(required = false) String status,
+            @RequestParam(required = false) String recruitType
+    ) {
+        return walkPostListService.list(page, size, regionId, status, recruitType);
+    }
+}

--- a/backend/src/main/java/kr/co/mongmate/api/walkpost/controller/WalkPostUpdateController.java
+++ b/backend/src/main/java/kr/co/mongmate/api/walkpost/controller/WalkPostUpdateController.java
@@ -1,0 +1,42 @@
+package kr.co.mongmate.api.walkpost.controller;
+
+import kr.co.mongmate.api.walkpost.dto.WalkPostUpdateRequest;
+import kr.co.mongmate.api.walkpost.dto.WalkPostUpdateResponse;
+import kr.co.mongmate.api.walkpost.service.WalkPostDeleteService;
+import kr.co.mongmate.api.walkpost.service.WalkPostUpdateService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.security.Principal;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/walk-posts")
+public class WalkPostUpdateController {
+
+    private final WalkPostUpdateService walkPostUpdateService;
+    private final WalkPostDeleteService walkPostDeleteService;
+
+    @PutMapping("/{postId}")
+    public WalkPostUpdateResponse update(
+            @PathVariable Long postId,
+            @RequestBody WalkPostUpdateRequest request,
+            Principal principal
+    ) {
+        String userId = principal != null ? principal.getName() : null;
+        return walkPostUpdateService.update(postId, userId, request);
+    }
+
+    @DeleteMapping("/{postId}")
+    public ResponseEntity<Void> delete(@PathVariable Long postId, Principal principal) {
+        String userId = principal != null ? principal.getName() : null;
+        walkPostDeleteService.delete(postId, userId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/backend/src/main/java/kr/co/mongmate/api/walkpost/dto/WalkPostCreateRequest.java
+++ b/backend/src/main/java/kr/co/mongmate/api/walkpost/dto/WalkPostCreateRequest.java
@@ -1,0 +1,13 @@
+package kr.co.mongmate.api.walkpost.dto;
+
+import java.time.LocalDateTime;
+
+public record WalkPostCreateRequest(
+        String title,
+        String content,
+        Long regionId,
+        LocalDateTime deadlineAt,
+        String meetAddress,
+        Double meetLat,
+        Double meetLng
+) {}

--- a/backend/src/main/java/kr/co/mongmate/api/walkpost/dto/WalkPostCreateResponse.java
+++ b/backend/src/main/java/kr/co/mongmate/api/walkpost/dto/WalkPostCreateResponse.java
@@ -1,0 +1,8 @@
+package kr.co.mongmate.api.walkpost.dto;
+
+import java.time.LocalDateTime;
+
+public record WalkPostCreateResponse(
+        Long postId,
+        LocalDateTime createdAt
+) {}

--- a/backend/src/main/java/kr/co/mongmate/api/walkpost/dto/WalkPostDetailResponse.java
+++ b/backend/src/main/java/kr/co/mongmate/api/walkpost/dto/WalkPostDetailResponse.java
@@ -1,0 +1,21 @@
+package kr.co.mongmate.api.walkpost.dto;
+
+import java.time.LocalDateTime;
+
+public record WalkPostDetailResponse(
+        Long postId,
+        String recruitType,
+        String title,
+        Author author,
+        Region region,
+        LocalDateTime deadlineAt,
+        String meetAddress,
+        String content,
+        String status,
+        LocalDateTime createdAt,
+        Chat chat
+) {
+    public record Author(Long userId, String nickname) {}
+    public record Region(Long regionId, String displayName) {}
+    public record Chat(boolean canChat, String roomId) {}
+}

--- a/backend/src/main/java/kr/co/mongmate/api/walkpost/dto/WalkPostListResponse.java
+++ b/backend/src/main/java/kr/co/mongmate/api/walkpost/dto/WalkPostListResponse.java
@@ -1,0 +1,30 @@
+package kr.co.mongmate.api.walkpost.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record WalkPostListResponse(
+        PageInfo page,
+        List<Item> items
+) {
+    public record PageInfo(
+            int page,
+            int size,
+            long totalElements,
+            int totalPages,
+            boolean hasNext
+    ) {}
+
+    public record Item(
+            Long postId,
+            String recruitType,
+            String title,
+            Region region,
+            LocalDateTime deadlineAt,
+            String authorNickname,
+            String status,
+            LocalDateTime createdAt
+    ) {}
+
+    public record Region(Long regionId, String displayName) {}
+}

--- a/backend/src/main/java/kr/co/mongmate/api/walkpost/dto/WalkPostUpdateRequest.java
+++ b/backend/src/main/java/kr/co/mongmate/api/walkpost/dto/WalkPostUpdateRequest.java
@@ -1,0 +1,12 @@
+package kr.co.mongmate.api.walkpost.dto;
+
+import java.time.LocalDateTime;
+
+public record WalkPostUpdateRequest(
+        String title,
+        String content,
+        LocalDateTime deadlineAt,
+        String meetAddress,
+        Long regionId,
+        String recruitType
+) {}

--- a/backend/src/main/java/kr/co/mongmate/api/walkpost/dto/WalkPostUpdateResponse.java
+++ b/backend/src/main/java/kr/co/mongmate/api/walkpost/dto/WalkPostUpdateResponse.java
@@ -1,0 +1,8 @@
+package kr.co.mongmate.api.walkpost.dto;
+
+import java.time.LocalDateTime;
+
+public record WalkPostUpdateResponse(
+        Long postId,
+        LocalDateTime updatedAt
+) {}

--- a/backend/src/main/java/kr/co/mongmate/api/walkpost/service/WalkPostCreateService.java
+++ b/backend/src/main/java/kr/co/mongmate/api/walkpost/service/WalkPostCreateService.java
@@ -1,0 +1,151 @@
+package kr.co.mongmate.api.walkpost.service;
+
+import kr.co.mongmate.api.walkpost.dto.WalkPostCreateRequest;
+import kr.co.mongmate.api.walkpost.dto.WalkPostCreateResponse;
+import kr.co.mongmate.domain.user.entity.User;
+import kr.co.mongmate.domain.user.repository.UserRepository;
+import kr.co.mongmate.domain.walkpost.entity.WalkPost;
+import kr.co.mongmate.domain.walkpost.repository.WalkPostRepository;
+import lombok.RequiredArgsConstructor;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Point;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class WalkPostCreateService {
+
+    private static final int TITLE_MAX_LENGTH = 100;
+    private static final int CONTENT_MAX_LENGTH = 5000;
+    private static final int MEET_ADDRESS_MAX_LENGTH = 200;
+
+    private static final double LAT_MIN = -90.0;
+    private static final double LAT_MAX = 90.0;
+    private static final double LNG_MIN = -180.0;
+    private static final double LNG_MAX = 180.0;
+
+    private static final boolean STORE_MEET_LOCATION = true; // TODO: set false if spatial (POINT) config is not ready
+
+    private final WalkPostRepository walkPostRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public WalkPostCreateResponse create(String userId, WalkPostCreateRequest request) {
+        if (request == null) {
+            throw badRequest("request body is required");
+        }
+
+        Long authorId = parseUserId(userId);
+
+        validateTitle(request.title());
+        validateContent(request.content());
+        validateRegionId(request.regionId());
+        validateDeadlineAt(request.deadlineAt());
+        validateMeetAddress(request.meetAddress());
+        validateMeetLatLng(request.meetLat(), request.meetLng());
+
+        User author = userRepository.getReferenceById(authorId);
+
+        Point meetLocation = resolveMeetLocation(request.meetLat(), request.meetLng());
+
+        WalkPost saved = walkPostRepository.save(
+                WalkPost.builder()
+                        .author(author)
+                        .title(request.title().trim())
+                        .content(request.content())
+                        .regionId(request.regionId())
+                        .deadlineAt(request.deadlineAt())
+                        .meetAddress(request.meetAddress())
+                        .meetLocation(meetLocation)
+                        .build()
+        );
+
+        return new WalkPostCreateResponse(saved.getId(), saved.getCreatedAt());
+    }
+
+    private void validateTitle(String title) {
+        if (title == null || title.trim().isEmpty()) {
+            throw badRequest("title is required");
+        }
+        int len = title.trim().length();
+        if (len < 1 || len > TITLE_MAX_LENGTH) {
+            throw badRequest("title length must be between 1 and " + TITLE_MAX_LENGTH);
+        }
+    }
+
+    private void validateContent(String content) {
+        if (content == null) return;
+        if (content.length() > CONTENT_MAX_LENGTH) {
+            throw badRequest("content length must be <= " + CONTENT_MAX_LENGTH);
+        }
+    }
+
+    private void validateRegionId(Long regionId) {
+        if (regionId == null || regionId < 1) {
+            throw badRequest("regionId must be positive");
+        }
+    }
+
+    private void validateDeadlineAt(LocalDateTime deadlineAt) {
+        if (deadlineAt == null) return;
+        if (deadlineAt.isBefore(LocalDateTime.now())) {
+            throw badRequest("deadlineAt must be in the future");
+        }
+    }
+
+    private void validateMeetAddress(String meetAddress) {
+        if (meetAddress == null) return;
+        if (meetAddress.length() > MEET_ADDRESS_MAX_LENGTH) {
+            throw badRequest("meetAddress length must be <= " + MEET_ADDRESS_MAX_LENGTH);
+        }
+    }
+
+    private void validateMeetLatLng(Double meetLat, Double meetLng) {
+        boolean hasLat = meetLat != null;
+        boolean hasLng = meetLng != null;
+
+        if (hasLat != hasLng) {
+            throw badRequest("meetLat and meetLng must be provided together");
+        }
+        if (!hasLat) return;
+
+        if (meetLat < LAT_MIN || meetLat > LAT_MAX) {
+            throw badRequest("meetLat out of range");
+        }
+        if (meetLng < LNG_MIN || meetLng > LNG_MAX) {
+            throw badRequest("meetLng out of range");
+        }
+    }
+
+    private Point resolveMeetLocation(Double meetLat, Double meetLng) {
+        if (meetLat == null || meetLng == null) {
+            return null;
+        }
+        if (!STORE_MEET_LOCATION) {
+            return null;
+        }
+        GeometryFactory factory = new GeometryFactory();
+        return factory.createPoint(new Coordinate(meetLng, meetLat));
+    }
+
+    private Long parseUserId(String userId) {
+        if (userId == null || userId.isBlank()) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "unauthorized");
+        }
+        try {
+            return Long.parseLong(userId);
+        } catch (NumberFormatException e) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "unauthorized");
+        }
+    }
+
+    private ResponseStatusException badRequest(String reason) {
+        return new ResponseStatusException(HttpStatus.BAD_REQUEST, reason);
+    }
+}

--- a/backend/src/main/java/kr/co/mongmate/api/walkpost/service/WalkPostDeleteService.java
+++ b/backend/src/main/java/kr/co/mongmate/api/walkpost/service/WalkPostDeleteService.java
@@ -1,0 +1,42 @@
+package kr.co.mongmate.api.walkpost.service;
+
+import kr.co.mongmate.domain.walkpost.entity.WalkPost;
+import kr.co.mongmate.domain.walkpost.repository.WalkPostRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+@Service
+@RequiredArgsConstructor
+public class WalkPostDeleteService {
+
+    private final WalkPostRepository walkPostRepository;
+
+    @Transactional
+    public void delete(Long postId, String userId) {
+        Long uid = parseUserId(userId);
+
+        WalkPost post = walkPostRepository.findByIdWithAuthor(postId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "walk post not found"));
+
+        if (post.getAuthor() == null || post.getAuthor().getId() == null
+                || !post.getAuthor().getId().equals(uid)) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "forbidden");
+        }
+
+        walkPostRepository.delete(post);
+    }
+
+    private Long parseUserId(String userId) {
+        if (userId == null || userId.isBlank()) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "unauthorized");
+        }
+        try {
+            return Long.parseLong(userId);
+        } catch (NumberFormatException e) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "unauthorized");
+        }
+    }
+}

--- a/backend/src/main/java/kr/co/mongmate/api/walkpost/service/WalkPostDetailService.java
+++ b/backend/src/main/java/kr/co/mongmate/api/walkpost/service/WalkPostDetailService.java
@@ -1,0 +1,61 @@
+package kr.co.mongmate.api.walkpost.service;
+
+import kr.co.mongmate.api.walkpost.dto.WalkPostDetailResponse;
+import kr.co.mongmate.domain.profile.entity.GuardianProfile;
+import kr.co.mongmate.domain.profile.repository.GuardianProfileRepository;
+import kr.co.mongmate.domain.user.entity.User;
+import kr.co.mongmate.domain.walkpost.entity.WalkPost;
+import kr.co.mongmate.domain.walkpost.repository.WalkPostRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class WalkPostDetailService {
+
+    private final WalkPostRepository walkPostRepository;
+    private final GuardianProfileRepository guardianProfileRepository;
+
+    public WalkPostDetailResponse getDetail(Long postId) {
+        WalkPost post = walkPostRepository.findByIdWithAuthor(postId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "walk post not found"));
+
+        User author = post.getAuthor();
+        Long authorId = author != null ? author.getId() : null;
+        String nickname = resolveNickname(authorId);
+
+        WalkPostDetailResponse.Author authorDto = new WalkPostDetailResponse.Author(authorId, nickname);
+        WalkPostDetailResponse.Region regionDto = new WalkPostDetailResponse.Region(post.getRegionId(), null);
+        WalkPostDetailResponse.Chat chatDto = new WalkPostDetailResponse.Chat(false, null);
+
+        String status = post.getStatus() != null ? post.getStatus().name() : null;
+
+        return new WalkPostDetailResponse(
+                post.getId(),
+                "WALK",
+                post.getTitle(),
+                authorDto,
+                regionDto,
+                post.getDeadlineAt(),
+                post.getMeetAddress(),
+                post.getContent(),
+                status,
+                post.getCreatedAt(),
+                chatDto
+        );
+    }
+
+    private String resolveNickname(Long authorId) {
+        if (authorId == null) {
+            return "알 수 없음";
+        }
+        Optional<GuardianProfile> profile = guardianProfileRepository.findById(authorId);
+        return profile.map(GuardianProfile::getNickname)
+                .filter(name -> !name.isBlank())
+                .orElse("알 수 없음");
+    }
+}

--- a/backend/src/main/java/kr/co/mongmate/api/walkpost/service/WalkPostListService.java
+++ b/backend/src/main/java/kr/co/mongmate/api/walkpost/service/WalkPostListService.java
@@ -1,0 +1,146 @@
+package kr.co.mongmate.api.walkpost.service;
+
+import kr.co.mongmate.api.walkpost.dto.WalkPostListResponse;
+import kr.co.mongmate.domain.profile.entity.GuardianProfile;
+import kr.co.mongmate.domain.profile.repository.GuardianProfileRepository;
+import kr.co.mongmate.domain.walkpost.entity.WalkPost;
+import kr.co.mongmate.domain.walkpost.repository.WalkPostRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class WalkPostListService {
+
+    private static final int DEFAULT_PAGE = 0;
+    private static final int DEFAULT_SIZE = 10;
+    private static final int MAX_SIZE = 50;
+
+    private final WalkPostRepository walkPostRepository;
+    private final GuardianProfileRepository guardianProfileRepository;
+
+    public WalkPostListResponse list(
+            Integer page,
+            Integer size,
+            Long regionId,
+            String status,
+            String recruitType
+    ) {
+        int resolvedPage = page != null ? page : DEFAULT_PAGE;
+        int resolvedSize = size != null ? size : DEFAULT_SIZE;
+
+        if (resolvedPage < 0 || resolvedSize < 0 || resolvedSize > MAX_SIZE) {
+            throw badRequest("invalid page/size");
+        }
+
+        WalkPost.Status statusFilter = parseStatus(status);
+        String recruitFilter = parseRecruitType(recruitType);
+
+        if (recruitFilter != null && !"WALK".equals(recruitFilter)) {
+            Pageable pageable = PageRequest.of(resolvedPage, resolvedSize, Sort.by(Sort.Direction.DESC, "createdAt"));
+            return emptyResponse(pageable);
+        }
+
+        Pageable pageable = PageRequest.of(resolvedPage, resolvedSize, Sort.by(Sort.Direction.DESC, "createdAt"));
+        Page<WalkPost> pageResult = walkPostRepository.findAllWithAuthor(regionId, statusFilter, pageable);
+
+        Map<Long, String> nicknameByUserId = loadNicknames(pageResult.getContent());
+
+        List<WalkPostListResponse.Item> items = pageResult.getContent().stream()
+                .map(post -> toItem(post, nicknameByUserId))
+                .toList();
+
+        WalkPostListResponse.PageInfo pageInfo = new WalkPostListResponse.PageInfo(
+                pageResult.getNumber(),
+                pageResult.getSize(),
+                pageResult.getTotalElements(),
+                pageResult.getTotalPages(),
+                pageResult.hasNext()
+        );
+
+        return new WalkPostListResponse(pageInfo, items);
+    }
+
+    private WalkPostListResponse emptyResponse(Pageable pageable) {
+        WalkPostListResponse.PageInfo pageInfo = new WalkPostListResponse.PageInfo(
+                pageable.getPageNumber(),
+                pageable.getPageSize(),
+                0,
+                0,
+                false
+        );
+        return new WalkPostListResponse(pageInfo, List.of());
+    }
+
+    private WalkPost.Status parseStatus(String status) {
+        String value = (status == null || status.isBlank()) ? "OPEN" : status.trim();
+        try {
+            return WalkPost.Status.valueOf(value.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw badRequest("invalid status");
+        }
+    }
+
+    private String parseRecruitType(String recruitType) {
+        if (recruitType == null || recruitType.isBlank()) {
+            return null;
+        }
+        String value = recruitType.trim().toUpperCase();
+        if (!"WALK".equals(value) && !"DOG_CAFE".equals(value)) {
+            throw badRequest("invalid recruitType");
+        }
+        return value;
+    }
+
+    private Map<Long, String> loadNicknames(Collection<WalkPost> posts) {
+        List<Long> userIds = posts.stream()
+                .map(post -> post.getAuthor() != null ? post.getAuthor().getId() : null)
+                .filter(id -> id != null)
+                .distinct()
+                .toList();
+        if (userIds.isEmpty()) {
+            return Map.of();
+        }
+        List<GuardianProfile> profiles = guardianProfileRepository.findAllByUserIdIn(userIds);
+        return profiles.stream()
+                .collect(Collectors.toMap(GuardianProfile::getUserId, GuardianProfile::getNickname));
+    }
+
+    private WalkPostListResponse.Item toItem(WalkPost post, Map<Long, String> nicknameByUserId) {
+        Long authorId = post.getAuthor() != null ? post.getAuthor().getId() : null;
+        String nickname = nicknameByUserId.get(authorId);
+        if (nickname == null || nickname.isBlank()) {
+            nickname = "알 수 없음";
+        }
+
+        WalkPostListResponse.Region region = new WalkPostListResponse.Region(post.getRegionId(), null);
+
+        String status = post.getStatus() != null ? post.getStatus().name() : null;
+
+        return new WalkPostListResponse.Item(
+                post.getId(),
+                "WALK",
+                post.getTitle(),
+                region,
+                post.getDeadlineAt(),
+                nickname,
+                status,
+                post.getCreatedAt()
+        );
+    }
+
+    private ResponseStatusException badRequest(String reason) {
+        return new ResponseStatusException(HttpStatus.BAD_REQUEST, reason);
+    }
+}

--- a/backend/src/main/java/kr/co/mongmate/api/walkpost/service/WalkPostUpdateService.java
+++ b/backend/src/main/java/kr/co/mongmate/api/walkpost/service/WalkPostUpdateService.java
@@ -1,0 +1,101 @@
+package kr.co.mongmate.api.walkpost.service;
+
+import kr.co.mongmate.api.walkpost.dto.WalkPostUpdateRequest;
+import kr.co.mongmate.api.walkpost.dto.WalkPostUpdateResponse;
+import kr.co.mongmate.domain.walkpost.entity.WalkPost;
+import kr.co.mongmate.domain.walkpost.repository.WalkPostRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class WalkPostUpdateService {
+
+    private static final int TITLE_MAX_LENGTH = 100;
+    private static final int CONTENT_MAX_LENGTH = 5000;
+    private static final int MEET_ADDRESS_MAX_LENGTH = 200;
+
+    private final WalkPostRepository walkPostRepository;
+
+    @Transactional
+    public WalkPostUpdateResponse update(Long postId, String userId, WalkPostUpdateRequest request) {
+        if (request == null) {
+            throw badRequest("request body is required");
+        }
+
+        Long uid = parseUserId(userId);
+
+        if (request.regionId() != null || request.recruitType() != null) {
+            throw badRequest("regionId/recruitType cannot be updated");
+        }
+
+        WalkPost post = walkPostRepository.findByIdWithAuthor(postId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "walk post not found"));
+
+        if (post.getAuthor() == null || post.getAuthor().getId() == null
+                || !post.getAuthor().getId().equals(uid)) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "forbidden");
+        }
+
+        boolean changed = false;
+
+        if (request.title() != null) {
+            String title = request.title().trim();
+            if (title.isEmpty() || title.length() > TITLE_MAX_LENGTH) {
+                throw badRequest("title length must be between 1 and " + TITLE_MAX_LENGTH);
+            }
+            post.changeTitle(title);
+            changed = true;
+        }
+
+        if (request.content() != null) {
+            if (request.content().length() > CONTENT_MAX_LENGTH) {
+                throw badRequest("content length must be <= " + CONTENT_MAX_LENGTH);
+            }
+            post.changeContent(request.content());
+            changed = true;
+        }
+
+        if (request.deadlineAt() != null) {
+            if (request.deadlineAt().isBefore(LocalDateTime.now())) {
+                throw badRequest("deadlineAt must be in the future");
+            }
+            post.changeDeadline(request.deadlineAt());
+            changed = true;
+        }
+
+        if (request.meetAddress() != null) {
+            if (request.meetAddress().length() > MEET_ADDRESS_MAX_LENGTH) {
+                throw badRequest("meetAddress length must be <= " + MEET_ADDRESS_MAX_LENGTH);
+            }
+            post.changeMeetAddress(request.meetAddress());
+            changed = true;
+        }
+
+        if (!changed) {
+            throw badRequest("no fields to update");
+        }
+
+        return new WalkPostUpdateResponse(post.getId(), post.getUpdatedAt());
+    }
+
+    private Long parseUserId(String userId) {
+        if (userId == null || userId.isBlank()) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "unauthorized");
+        }
+        try {
+            return Long.parseLong(userId);
+        } catch (NumberFormatException e) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "unauthorized");
+        }
+    }
+
+    private ResponseStatusException badRequest(String reason) {
+        return new ResponseStatusException(HttpStatus.BAD_REQUEST, reason);
+    }
+}

--- a/backend/src/main/java/kr/co/mongmate/domain/chat/entity/ChatThread.java
+++ b/backend/src/main/java/kr/co/mongmate/domain/chat/entity/ChatThread.java
@@ -49,6 +49,9 @@ public class ChatThread {
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
     @OneToMany(
             mappedBy = "chatThread",
             cascade = CascadeType.ALL   // 메시지는 스레드 라이프사이클에 따라 생성/삭제
@@ -94,7 +97,8 @@ public class ChatThread {
         this.walkPost = walkPost;
         this.author = author;
         this.participant = participant;
-        this.createdAt = createdAt;
+        this.createdAt = createdAt != null ? createdAt : LocalDateTime.now();
+        this.updatedAt = this.createdAt;
     }
 
     /**
@@ -123,6 +127,10 @@ public class ChatThread {
         if (!messages.contains(message)) {
             messages.add(message);
         }
+    }
+
+    public void touchUpdatedAt(LocalDateTime timestamp) {
+        this.updatedAt = timestamp != null ? timestamp : LocalDateTime.now();
     }
 
 }

--- a/backend/src/main/java/kr/co/mongmate/domain/chat/repository/ChatReadStateRepository.java
+++ b/backend/src/main/java/kr/co/mongmate/domain/chat/repository/ChatReadStateRepository.java
@@ -3,9 +3,22 @@ package kr.co.mongmate.domain.chat.repository;
 import kr.co.mongmate.domain.chat.entity.ChatReadState;
 import kr.co.mongmate.domain.chat.entity.ChatReadStateId;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface ChatReadStateRepository extends JpaRepository<ChatReadState, ChatReadStateId> {
 
     // ✅ 멤버십 존재 여부 = chat_read_state에 (threadId, userId) row가 있는가?
     boolean existsByIdThreadIdAndIdUserId(Long threadId, Long userId);
+
+    @Query("""
+            select crs from ChatReadState crs
+            join fetch crs.chatThread ct
+            join fetch ct.author
+            join fetch ct.participant
+            where crs.user.id = :userId
+            """)
+    List<ChatReadState> findAllByUserIdWithThread(@Param("userId") Long userId);
 }

--- a/backend/src/main/java/kr/co/mongmate/domain/chat/service/ChatMessageService.java
+++ b/backend/src/main/java/kr/co/mongmate/domain/chat/service/ChatMessageService.java
@@ -10,6 +10,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+
 @Service
 @RequiredArgsConstructor
 public class ChatMessageService {
@@ -27,16 +29,20 @@ public class ChatMessageService {
         ChatThread thread = chatThreadRepository.getReferenceById(threadId);
         User sender = userRepository.getReferenceById(senderId);
 
+        LocalDateTime now = LocalDateTime.now();
+
         ChatMessage saved = chatMessageRepository.save(
                 ChatMessage.builder()
                         .chatThread(thread)
                         .sender(sender)
                         .content(content)
+                        .sentAt(now)
                         .build()
         );
+
+        thread.touchUpdatedAt(now);
 
         return saved.getId();
     }
 }
-
 

--- a/backend/src/main/java/kr/co/mongmate/domain/profile/repository/GuardianProfileRepository.java
+++ b/backend/src/main/java/kr/co/mongmate/domain/profile/repository/GuardianProfileRepository.java
@@ -1,0 +1,12 @@
+package kr.co.mongmate.domain.profile.repository;
+
+import kr.co.mongmate.domain.profile.entity.GuardianProfile;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Collection;
+import java.util.List;
+
+public interface GuardianProfileRepository extends JpaRepository<GuardianProfile, Long> {
+
+    List<GuardianProfile> findAllByUserIdIn(Collection<Long> userIds);
+}

--- a/backend/src/main/java/kr/co/mongmate/domain/walkpost/entity/WalkPost.java
+++ b/backend/src/main/java/kr/co/mongmate/domain/walkpost/entity/WalkPost.java
@@ -10,6 +10,7 @@ import kr.co.mongmate.domain.user.entity.User;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.lang.NonNull;
 
 @Entity
 @Table(
@@ -275,7 +276,7 @@ public class WalkPost {
             return this;
         }
 
-        public WalkPost build() {
+        public @NonNull WalkPost build() {
             Objects.requireNonNull(author, "author must not be null");
             Objects.requireNonNull(title, "title must not be null");
             Objects.requireNonNull(regionId, "regionId must not be null");

--- a/backend/src/main/java/kr/co/mongmate/domain/walkpost/repository/WalkPostRepository.java
+++ b/backend/src/main/java/kr/co/mongmate/domain/walkpost/repository/WalkPostRepository.java
@@ -1,0 +1,39 @@
+package kr.co.mongmate.domain.walkpost.repository;
+
+import kr.co.mongmate.domain.walkpost.entity.WalkPost;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.Optional;
+
+public interface WalkPostRepository extends JpaRepository<WalkPost, Long> {
+
+    @Query("""
+            select wp from WalkPost wp
+            join fetch wp.author
+            where wp.id = :postId
+            """)
+    Optional<WalkPost> findByIdWithAuthor(@Param("postId") Long postId);
+
+    @Query(
+            value = """
+                    select wp from WalkPost wp
+                    join fetch wp.author
+                    where (:regionId is null or wp.regionId = :regionId)
+                      and (:status is null or wp.status = :status)
+                    """,
+            countQuery = """
+                    select count(wp) from WalkPost wp
+                    where (:regionId is null or wp.regionId = :regionId)
+                      and (:status is null or wp.status = :status)
+                    """
+    )
+    Page<WalkPost> findAllWithAuthor(
+            @Param("regionId") Long regionId,
+            @Param("status") WalkPost.Status status,
+            Pageable pageable
+    );
+}

--- a/backend/src/main/java/kr/co/mongmate/infra/chat/service/ChatRedisService.java
+++ b/backend/src/main/java/kr/co/mongmate/infra/chat/service/ChatRedisService.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Service;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.OptionalLong;
 
 @Service
 @RequiredArgsConstructor
@@ -45,6 +46,14 @@ public class ChatRedisService {
         if (v == null) return 0L;
         try { return Long.parseLong(v); }
         catch (NumberFormatException e) { return 0L; }
+    }
+
+    /** 유저 lastReadSeq 조회 (없으면 OptionalLong.empty) */
+    public OptionalLong getLastReadSeqIfPresent(String roomId, String userId) {
+        String v = redisTemplate.opsForValue().get(readKey(roomId, userId));
+        if (v == null) return OptionalLong.empty();
+        try { return OptionalLong.of(Long.parseLong(v)); }
+        catch (NumberFormatException e) { return OptionalLong.empty(); }
     }
 
 
@@ -87,4 +96,3 @@ public class ChatRedisService {
         }
     }
 }
-


### PR DESCRIPTION

---

### 1. 산책 모집글 CRUD API
 **Create (생성)**
* **검증:** 필수 값 유효성 체크
* **초기화:** `status` (모집중), `viewCount`(0), `likeCount`(0)


**Read (상세 조회)**
* **반환:** 작성자, 지역, 마감 시간, 장소, 상세 내용


**Update (수정)**
* **권한:** 작성자 본인 확인
* **필드:** 제목, 내용, 마감 시간, 장소 (부분 수정 가능)


**Delete (삭제)**
* **권한:** 작성자 본인 확인
* **방식:** 물리 삭제 (Hard Delete)




### 2. 산책 모집글 목록 조회 API

**정렬 및 페이징**
* 최신순 정렬
* `page`, `size` 기반 페이지네이션 지원


**필터 기능**
* `regionId` (지역)
* `status` (기본값: OPEN)
* `recruitType` (산책 / 애견카페)


* **최적화**
* 카드 UI용 필수 데이터만 선별 조회



---
