### PR TITLE
[feat (auth,chat)] - 토큰 갱신 및 WS 재연결 안정화

### DIFF
--- a/backend/src/main/java/kr/co/mongmate/api/auth/controller/AuthController.java
+++ b/backend/src/main/java/kr/co/mongmate/api/auth/controller/AuthController.java
@@ -2,6 +2,7 @@ package kr.co.mongmate.api.auth.controller;
 
 import kr.co.mongmate.api.auth.dto.*;
 import kr.co.mongmate.api.auth.service.LoginService;
+import kr.co.mongmate.api.auth.service.RefreshTokenService;
 import kr.co.mongmate.api.auth.service.SignUpService;
 import kr.co.mongmate.api.auth.service.SmsAuthService;
 import lombok.RequiredArgsConstructor;
@@ -19,6 +20,7 @@ public class AuthController {
     private final SmsAuthService smsAuthService;
     private final SignUpService signUpService;
     private final LoginService loginService;
+    private final RefreshTokenService refreshTokenService;
 
 
     /**
@@ -58,6 +60,15 @@ public class AuthController {
     @PostMapping("/login")
     public ResponseEntity<LoginResponse> login(@RequestBody LoginRequest request) {
         LoginResponse response = loginService.login(request);
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 토큰 재발급 (refresh)
+     */
+    @PostMapping("/refresh")
+    public ResponseEntity<RefreshTokenResponse> refresh(@RequestBody RefreshTokenRequest request) {
+        RefreshTokenResponse response = refreshTokenService.refresh(request);
         return ResponseEntity.ok(response);
     }
 

--- a/backend/src/main/java/kr/co/mongmate/api/auth/dto/RefreshTokenRequest.java
+++ b/backend/src/main/java/kr/co/mongmate/api/auth/dto/RefreshTokenRequest.java
@@ -1,0 +1,10 @@
+package kr.co.mongmate.api.auth.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class RefreshTokenRequest {
+    private String refreshToken;
+}

--- a/backend/src/main/java/kr/co/mongmate/api/auth/dto/RefreshTokenResponse.java
+++ b/backend/src/main/java/kr/co/mongmate/api/auth/dto/RefreshTokenResponse.java
@@ -1,0 +1,12 @@
+package kr.co.mongmate.api.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class RefreshTokenResponse {
+    private Long userId;
+    private String accessToken;
+    private String refreshToken;
+}

--- a/backend/src/main/java/kr/co/mongmate/api/auth/service/JwtProvider.java
+++ b/backend/src/main/java/kr/co/mongmate/api/auth/service/JwtProvider.java
@@ -2,9 +2,14 @@ package kr.co.mongmate.api.auth.service;
 
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
 import java.util.Date;
 
 @Component
@@ -13,11 +18,24 @@ public class JwtProvider {
     @Value("${jwt.secret}")
     private String secretKey;
 
+    private Key key;
+
+    @PostConstruct
+    void init() {
+        byte[] keyBytes;
+        try {
+            keyBytes = Decoders.BASE64.decode(secretKey);
+        } catch (IllegalArgumentException e) {
+            keyBytes = secretKey.getBytes(StandardCharsets.UTF_8);
+        }
+        this.key = Keys.hmacShaKeyFor(keyBytes);
+    }
+
     public String generateAccessToken(Long userId) {
         return Jwts.builder()
                 .setSubject(String.valueOf(userId))
                 .setExpiration(new Date(System.currentTimeMillis() + 1000 * 60 * 60)) // 1시간
-                .signWith(SignatureAlgorithm.HS256, secretKey)
+                .signWith(key, SignatureAlgorithm.HS256)
                 .compact();
     }
 
@@ -25,7 +43,7 @@ public class JwtProvider {
         return Jwts.builder()
                 .setSubject(String.valueOf(userId))
                 .setExpiration(new Date(System.currentTimeMillis() + 1000L * 60 * 60 * 24 * 14)) // 2주
-                .signWith(SignatureAlgorithm.HS256, secretKey.getBytes())
+                .signWith(key, SignatureAlgorithm.HS256)
                 .compact();
     }
 }

--- a/backend/src/main/java/kr/co/mongmate/api/auth/service/RefreshTokenService.java
+++ b/backend/src/main/java/kr/co/mongmate/api/auth/service/RefreshTokenService.java
@@ -1,0 +1,66 @@
+package kr.co.mongmate.api.auth.service;
+
+import io.jsonwebtoken.JwtException;
+import kr.co.mongmate.api.auth.dto.RefreshTokenRequest;
+import kr.co.mongmate.api.auth.dto.RefreshTokenResponse;
+import kr.co.mongmate.domain.user.repository.UserRepository;
+import kr.co.mongmate.infra.security.jwt.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+@Service
+@RequiredArgsConstructor
+public class RefreshTokenService {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final JwtProvider jwtProvider;
+    private final UserRepository userRepository;
+
+    @Transactional(readOnly = true)
+    public RefreshTokenResponse refresh(RefreshTokenRequest request) {
+        if (request == null || request.getRefreshToken() == null || request.getRefreshToken().isBlank()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "INVALID_REFRESH_TOKEN");
+        }
+
+        String token = stripBearer(request.getRefreshToken());
+
+        String subject;
+        try {
+            subject = jwtTokenProvider.getSubject(token);
+        } catch (JwtException e) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "INVALID_REFRESH_TOKEN");
+        }
+
+        Long userId = parseUserId(subject);
+        if (!userRepository.existsById(userId)) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "INVALID_REFRESH_TOKEN");
+        }
+
+        String newAccess = jwtProvider.generateAccessToken(userId);
+        String newRefresh = jwtProvider.generateRefreshToken(userId);
+
+        return new RefreshTokenResponse(userId, newAccess, newRefresh);
+    }
+
+    private Long parseUserId(String subject) {
+        if (subject == null || subject.isBlank()) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "INVALID_REFRESH_TOKEN");
+        }
+        try {
+            return Long.parseLong(subject);
+        } catch (NumberFormatException e) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "INVALID_REFRESH_TOKEN");
+        }
+    }
+
+    private String stripBearer(String token) {
+        String t = token.trim();
+        if (t.regionMatches(true, 0, "Bearer ", 0, 7)) {
+            return t.substring(7).trim();
+        }
+        return t;
+    }
+}

--- a/backend/src/main/java/kr/co/mongmate/api/walkpost/service/WalkPostMyListService.java
+++ b/backend/src/main/java/kr/co/mongmate/api/walkpost/service/WalkPostMyListService.java
@@ -4,7 +4,7 @@ import kr.co.mongmate.api.walkpost.dto.WalkPostMyListItem;
 import kr.co.mongmate.api.walkpost.dto.WalkPostMyListResponse;
 import kr.co.mongmate.api.walkpost.exception.WalkPostException;
 import kr.co.mongmate.domain.walkpost.entity.WalkPost;
-import kr.co.mongmate.domain.walkpost.enum.WalkPostStatus;
+import kr.co.mongmate.domain.walkpost.status.WalkPostStatus;
 import kr.co.mongmate.domain.walkpost.repository.WalkPostRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;

--- a/backend/src/main/java/kr/co/mongmate/api/walkpost/service/WalkPostStatusService.java
+++ b/backend/src/main/java/kr/co/mongmate/api/walkpost/service/WalkPostStatusService.java
@@ -4,7 +4,7 @@ import kr.co.mongmate.api.walkpost.dto.WalkPostStatusChangeRequest;
 import kr.co.mongmate.api.walkpost.dto.WalkPostStatusChangeResponse;
 import kr.co.mongmate.api.walkpost.exception.WalkPostException;
 import kr.co.mongmate.domain.walkpost.entity.WalkPost;
-import kr.co.mongmate.domain.walkpost.enum.WalkPostStatus;
+import kr.co.mongmate.domain.walkpost.status.WalkPostStatus;
 import kr.co.mongmate.domain.walkpost.repository.WalkPostRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;

--- a/backend/src/main/java/kr/co/mongmate/domain/walkpost/status/WalkPostStatus.java
+++ b/backend/src/main/java/kr/co/mongmate/domain/walkpost/status/WalkPostStatus.java
@@ -1,4 +1,4 @@
-package kr.co.mongmate.domain.walkpost.enum;
+package kr.co.mongmate.domain.walkpost.status;
 
 import kr.co.mongmate.domain.walkpost.entity.WalkPost;
 

--- a/backend/src/main/java/kr/co/mongmate/infra/security/jwt/JwtTokenProvider.java
+++ b/backend/src/main/java/kr/co/mongmate/infra/security/jwt/JwtTokenProvider.java
@@ -84,6 +84,11 @@ public class JwtTokenProvider {
                 .getBody();
     }
 
+    public String getSubject(String token) {
+        Claims claims = parseClaims(token);
+        return claims.getSubject();
+    }
+
     private List<SimpleGrantedAuthority> extractAuthorities(Claims claims) {
         Object rolesObj = claims.get(ROLES_CLAIM);
 

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -45,3 +45,11 @@ export async function login(phoneNumber: string) {
     body: JSON.stringify({ phoneNumber }),
   });
 }
+
+export async function refreshTokens(refreshToken: string) {
+  return apiFetch<AuthResponse>("/api/auth/refresh", {
+    method: "POST",
+    auth: "none",
+    body: JSON.stringify({ refreshToken }),
+  });
+}

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,4 +1,5 @@
 import { useAuthStore } from "../store/auth";
+import { tokenStorage } from "../lib/tokenStorage";
 
 const BASE_URL = "http://localhost:8080";
 
@@ -7,6 +8,7 @@ type AuthMode = "auto" | "required" | "none";
 type ApiFetchOptions = RequestInit & {
   auth?: AuthMode; // ✅ 기본 auto
   debug?: boolean; // ✅ true면 요청헤더 콘솔 출력
+  _retry?: boolean; // 내부용 (재시도 방지)
 };
 
 /**
@@ -50,12 +52,43 @@ async function readBodySafe(res: Response) {
   }
 }
 
+let refreshPromise: Promise<null | { userId: number; accessToken: string; refreshToken: string }> | null = null;
+
+async function refreshAccessToken() {
+  if (refreshPromise) return refreshPromise;
+
+  refreshPromise = (async () => {
+    const refreshToken = await tokenStorage.getRefreshToken();
+    if (!refreshToken) return null;
+
+    const res = await fetch(`${BASE_URL}/api/auth/refresh`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Accept: "application/json" },
+      body: JSON.stringify({ refreshToken }),
+    });
+
+    const data = await readBodySafe(res);
+    if (!res.ok) return null;
+
+    if (!data || typeof data !== "object") return null;
+    const { userId, accessToken, refreshToken: newRefresh } = data as any;
+    if (!accessToken || !newRefresh) return null;
+    return { userId, accessToken, refreshToken: newRefresh };
+  })();
+
+  try {
+    return await refreshPromise;
+  } finally {
+    refreshPromise = null;
+  }
+}
+
 export async function apiFetch<T>(
   path: string,
   options: ApiFetchOptions = {},
 ): Promise<T> {
   const url = path.startsWith("http") ? path : `${BASE_URL}${path}`;
-  const { auth = "auto", debug = false, headers, ...rest } = options;
+  const { auth = "auto", debug = false, headers, _retry, ...rest } = options;
 
   // ✅ store에서 토큰 가져오기 (필드명이 다르면 여기만 맞추면 됨)
   const token = useAuthStore.getState().accessToken;
@@ -105,8 +138,20 @@ export async function apiFetch<T>(
 
   const res = await fetch(url, { ...rest, headers: finalHeaders });
   const data = await readBodySafe(res);
-  if (res.status === 401) {
-    // 토큰 만료/무효 → 세션 정리
+
+  if (res.status === 401 && auth !== "none" && !_retry) {
+    const refreshed = await refreshAccessToken();
+    if (refreshed) {
+      const { setSession } = useAuthStore.getState();
+      await setSession({
+        userId: refreshed.userId,
+        accessToken: refreshed.accessToken,
+        refreshToken: refreshed.refreshToken,
+      });
+      return apiFetch<T>(path, { ...options, _retry: true });
+    }
+
+    // refresh 실패 → 세션 정리
     try {
       const { logout } = useAuthStore.getState();
       if (logout) await logout();

--- a/frontend/src/screens/auth/AuthOtpScreen.tsx
+++ b/frontend/src/screens/auth/AuthOtpScreen.tsx
@@ -45,7 +45,6 @@ export default function AuthOtpScreen() {
 
   const hydrated = useAuthStore((s) => s.hydrated);
   const setSession = useAuthStore((s: AuthState) => s.setSession);
-  const setTokens = useAuthStore((s: AuthState) => s.setTokens);
 
   const [phone, setPhone] = React.useState(initialPhoneNumber ?? "");
   const [phoneLocked, setPhoneLocked] = React.useState(mode === "signup");
@@ -163,7 +162,6 @@ export default function AuthOtpScreen() {
           accessToken: res.accessToken,
           refreshToken: res.refreshToken,
         });
-        await setTokens(res.accessToken, res.refreshToken);
 
         navigation.navigate("Main");
         return;
@@ -178,7 +176,6 @@ export default function AuthOtpScreen() {
         accessToken: res.accessToken,
         refreshToken: res.refreshToken,
       });
-      await setTokens(res.accessToken, res.refreshToken);
 
       navigation.navigate("Main");
     } catch (e: any) {

--- a/frontend/src/screens/auth/AuthStartScreen.tsx
+++ b/frontend/src/screens/auth/AuthStartScreen.tsx
@@ -16,7 +16,6 @@ const DEV_PHONE = "01040014908";
 export default function AuthStartScreen() {
   const navigation = useNavigation<Nav>();
   const setSession = useAuthStore((s) => s.setSession);
-  const setTokens = useAuthStore((s) => s.setTokens);
 
   const onDevLogin = async () => {
     try {
@@ -28,7 +27,6 @@ export default function AuthStartScreen() {
         accessToken: res.accessToken,
         refreshToken: res.refreshToken,
       });
-      await setTokens(res.accessToken, res.refreshToken);
 
       navigation.navigate("Main");
     } catch (e: any) {

--- a/frontend/src/store/auth.ts
+++ b/frontend/src/store/auth.ts
@@ -113,8 +113,12 @@ export const useAuthStore = create<AuthState>((set, get) => ({
       isAuthed: true,
     });
 
-    // ✅ 토큰이 유효할 때만 warm-up
-    ensureChatSocket().catch(() => {});
+    // ✅ 토큰 저장 직후 재연결(동기 타이밍 보장)
+    try {
+      await ensureChatSocket();
+    } catch {
+      // 연결 실패는 무시 (UI에서 재시도 가능)
+    }
   },
 
   setSession: async (session: Session) => {

--- a/frontend/src/ws/chatClient.ts
+++ b/frontend/src/ws/chatClient.ts
@@ -1,11 +1,16 @@
 import SockJS from "sockjs-client";
 import { Client, IMessage } from "@stomp/stompjs";
 import { tokenStorage } from "../lib/tokenStorage";
+import { refreshTokens } from "../api/auth";
+import { useAuthStore } from "../store/auth";
 
 const WS_URL = "http://localhost:8080/ws-chat";
 
 let client: Client | null = null;
 let connectingPromise: Promise<Client> | null = null;
+let lastToken: string | null = null;
+let suspendReconnectUntil: number | null = null;
+let refreshPromise: Promise<string | null> | null = null;
 
 export type SendChatPayload = {
   roomId: string;
@@ -24,45 +29,180 @@ function debugLog(msg: string, ...args: any[]) {
   console.log("[chatClient]", msg, ...args);
 }
 
+function decodeJwtExp(token: string): number | null {
+  try {
+    const payload = token.split(".")[1];
+    if (!payload) return null;
+    const b64 = payload.replace(/-/g, "+").replace(/_/g, "/");
+    const json =
+      typeof atob === "function"
+        ? atob(b64)
+        : Buffer.from(b64, "base64").toString("utf-8");
+    const data = JSON.parse(json);
+    return typeof data.exp === "number" ? data.exp * 1000 : null;
+  } catch {
+    return null;
+  }
+}
+
+async function ensureFreshAccessToken(rawToken: string): Promise<string> {
+  const expMs = decodeJwtExp(rawToken);
+  const now = Date.now();
+  const shouldRefresh = expMs !== null && expMs <= now + 30_000; // 30s 여유
+
+  if (!shouldRefresh) return rawToken;
+
+  if (!refreshPromise) {
+    refreshPromise = (async () => {
+      const rt = await tokenStorage.getRefreshToken();
+      if (!rt) return null;
+      try {
+        const refreshed = await refreshTokens(rt);
+        const { setSession } = useAuthStore.getState();
+        await setSession({
+          userId: refreshed.userId,
+          accessToken: refreshed.accessToken,
+          refreshToken: refreshed.refreshToken,
+        });
+        return refreshed.accessToken;
+      } catch {
+        return null;
+      } finally {
+        refreshPromise = null;
+      }
+    })();
+  }
+
+  const newToken = await refreshPromise;
+  if (newToken) return newToken;
+
+  // ✅ refresh 실패 + 만료 임박/만료 토큰이면 연결 차단
+  suspendReconnectUntil = Date.now() + 5 * 60 * 1000; // 5분
+  try {
+    const { logout } = useAuthStore.getState();
+    await logout?.();
+  } catch {}
+  throw new Error("accessToken expired and refresh failed");
+}
+
 export async function ensureChatSocket(): Promise<Client> {
+  if (suspendReconnectUntil && Date.now() < suspendReconnectUntil) {
+    throw new Error("STOMP reconnect suspended (expired token)");
+  }
+
+  const rawAccessToken = await tokenStorage.getAccessToken();
+  if (!rawAccessToken) throw new Error("accessToken이 비어있습니다.");
+
+  const accessToken = await ensureFreshAccessToken(rawAccessToken);
+  if (!accessToken) throw new Error("accessToken이 비어있습니다.");
+
+  // ✅ 토큰이 바뀌면 기존 소켓 정리 후 재생성
+  if (lastToken && lastToken !== accessToken) {
+    await disconnectChatSocket();
+  }
+
   if (client && client.connected) return client;
   if (connectingPromise) return connectingPromise;
 
   connectingPromise = (async () => {
-    const accessToken = await tokenStorage.getAccessToken();
-    if (!accessToken) throw new Error("accessToken이 비어있습니다.");
-
     const c = new Client({
       webSocketFactory: () => new SockJS(WS_URL),
-      connectHeaders: {
-        Authorization: `Bearer ${accessToken}`,
-      },
       debug: (str) => console.log("[STOMP]", str),
       reconnectDelay: 3000,
       heartbeatIncoming: 10000,
       heartbeatOutgoing: 10000,
     });
 
-    await new Promise<void>((resolve, reject) => {
-      c.onConnect = () => {
-        debugLog("✅ STOMP connected:", WS_URL);
-        resolve();
-      };
-      c.onStompError = (frame) => {
-        console.error("[STOMP] stomp error", frame.headers, frame.body);
-        reject(new Error(frame.body || "STOMP error"));
-      };
-      c.onWebSocketError = (e) => {
-        console.error("[STOMP] websocket error", e);
-        reject(new Error("WebSocket error"));
-      };
+    // ✅ 재연결 시마다 최신 토큰으로 CONNECT 헤더 갱신
+    c.beforeConnect = async () => {
+      const tokenRaw = await tokenStorage.getAccessToken();
+      if (!tokenRaw) throw new Error("accessToken이 비어있습니다.");
+      const token = await ensureFreshAccessToken(tokenRaw);
+      if (!token) throw new Error("accessToken이 비어있습니다.");
+      c.connectHeaders = { Authorization: `Bearer ${token}` };
+    };
 
-      c.activate();
-    });
+    try {
+      await new Promise<void>((resolve, reject) => {
+        let settled = false;
 
-    client = c;
-    connectingPromise = null;
-    return c;
+        const fail = (err: Error) => {
+          if (settled) return;
+          settled = true;
+          reject(err);
+        };
+
+        c.onConnect = () => {
+          if (settled) return;
+          settled = true;
+          debugLog("✅ STOMP connected:", WS_URL);
+          resolve();
+        };
+        c.onStompError = async (frame) => {
+          console.error("[STOMP] stomp error", frame.headers, frame.body);
+
+          const body = frame.body || "";
+          if (body.includes("Expired JWT") || body.includes("ExpiredJwt")) {
+            try {
+              const rt = await tokenStorage.getRefreshToken();
+              if (!rt) throw new Error("refreshToken이 비어있습니다.");
+
+              const refreshed = await refreshTokens(rt);
+              const { setSession } = useAuthStore.getState();
+              await setSession({
+                userId: refreshed.userId,
+                accessToken: refreshed.accessToken,
+                refreshToken: refreshed.refreshToken,
+              });
+
+              await disconnectChatSocket();
+              await ensureChatSocket();
+              return;
+            } catch (e) {
+              // ✅ refresh 실패 시 재연결 루프 중단 + 로그아웃 유도
+              suspendReconnectUntil = Date.now() + 5 * 60 * 1000; // 5분
+              try {
+                const { logout } = useAuthStore.getState();
+                await logout?.();
+              } catch {}
+              fail(new Error("STOMP expired + refresh failed"));
+              return;
+            }
+          }
+
+          fail(new Error(frame.body || "STOMP error"));
+        };
+        c.onWebSocketError = (e) => {
+          console.error("[STOMP] websocket error", e);
+          fail(new Error("WebSocket error"));
+        };
+        c.onWebSocketClose = (evt) => {
+          console.warn("[STOMP] websocket closed", evt.code, evt.reason);
+          // 1002: protocol error (서버 인증 실패 시 흔함)
+          if (!settled) {
+            fail(new Error(`WebSocket closed (code=${evt.code})`));
+          }
+        };
+
+        c.activate();
+      });
+
+      client = c;
+      lastToken = accessToken;
+      return c;
+    } catch (err) {
+      try {
+        await c.deactivate();
+      } catch {}
+      throw err;
+    } finally {
+      // 실패/성공 모두 정리: 다음 connect 시도 가능하게
+      connectingPromise = null;
+      if (!c.connected) {
+        client = null;
+        lastToken = null;
+      }
+    }
   })();
 
   return connectingPromise;
@@ -77,6 +217,7 @@ export async function disconnectChatSocket() {
   } finally {
     client = null;
     connectingPromise = null;
+    lastToken = null;
   }
 }
 


### PR DESCRIPTION

1. refresh API 추가로 access/refresh 재발급 지원
2. apiFetch 401 시 refresh → 재시도 로직 구현
3. 토큰 저장 직후 WS 재연결 보장
4. STOMP 만료 감지 시 refresh 후 재연결, 실패 시 재연결 중단 처리