### PR TITLE
[feat(profile, photo)] - 산책글 사진 노출 + 신규 프로필 설정 플로우 추가

### DIFF
--- a/backend/src/main/java/kr/co/mongmate/api/walkpost/dto/WalkPostDetailResponse.java
+++ b/backend/src/main/java/kr/co/mongmate/api/walkpost/dto/WalkPostDetailResponse.java
@@ -1,6 +1,7 @@
 package kr.co.mongmate.api.walkpost.dto;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 public record WalkPostDetailResponse(
         Long postId,
@@ -11,6 +12,7 @@ public record WalkPostDetailResponse(
         LocalDateTime deadlineAt,
         String meetAddress,
         String content,
+        List<String> photoUrls,
         String status,
         LocalDateTime createdAt,
         Chat chat

--- a/backend/src/main/java/kr/co/mongmate/api/walkpost/dto/WalkPostListResponse.java
+++ b/backend/src/main/java/kr/co/mongmate/api/walkpost/dto/WalkPostListResponse.java
@@ -19,6 +19,7 @@ public record WalkPostListResponse(
             Long postId,
             String recruitType,
             String title,
+            String photoUrl,
             Region region,
             LocalDateTime deadlineAt,
             String authorNickname,

--- a/backend/src/main/java/kr/co/mongmate/api/walkpost/service/WalkPostDetailService.java
+++ b/backend/src/main/java/kr/co/mongmate/api/walkpost/service/WalkPostDetailService.java
@@ -10,6 +10,8 @@ import kr.co.mongmate.domain.profile.repository.GuardianProfileRepository;
 import kr.co.mongmate.domain.user.entity.User;
 import kr.co.mongmate.domain.user.repository.UserRepository;
 import kr.co.mongmate.domain.walkpost.entity.WalkPost;
+import kr.co.mongmate.domain.walkpost.entity.WalkPostPhoto;
+import kr.co.mongmate.domain.walkpost.repository.WalkPostPhotoRepository;
 import kr.co.mongmate.domain.walkpost.repository.WalkPostRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -30,6 +32,7 @@ public class WalkPostDetailService {
     private final ChatThreadRepository chatThreadRepository;
     private final ChatReadStateRepository chatReadStateRepository;
     private final UserRepository userRepository;
+    private final WalkPostPhotoRepository walkPostPhotoRepository;
 
     @Transactional
     public WalkPostDetailResponse getDetail(Long postId, String userId) {
@@ -43,6 +46,7 @@ public class WalkPostDetailService {
         WalkPostDetailResponse.Author authorDto = new WalkPostDetailResponse.Author(authorId, nickname);
         WalkPostDetailResponse.Region regionDto = new WalkPostDetailResponse.Region(post.getRegionId(), null);
         WalkPostDetailResponse.Chat chatDto = resolveChatInfo(post, userId);
+        java.util.List<String> photoUrls = loadPhotoUrls(post.getId());
 
         String status = post.getStatus() != null ? post.getStatus().name() : null;
 
@@ -55,10 +59,20 @@ public class WalkPostDetailService {
                 post.getDeadlineAt(),
                 post.getMeetAddress(),
                 post.getContent(),
+                photoUrls,
                 status,
                 post.getCreatedAt(),
                 chatDto
         );
+    }
+
+    private java.util.List<String> loadPhotoUrls(Long postId) {
+        if (postId == null) {
+            return java.util.List.of();
+        }
+        return walkPostPhotoRepository.findAllByWalkPostIdOrderBySortOrderAsc(postId).stream()
+                .map(WalkPostPhoto::getPhotoUrl)
+                .toList();
     }
 
     private String resolveNickname(Long authorId) {

--- a/backend/src/main/java/kr/co/mongmate/api/walkpost/service/WalkPostListService.java
+++ b/backend/src/main/java/kr/co/mongmate/api/walkpost/service/WalkPostListService.java
@@ -4,6 +4,8 @@ import kr.co.mongmate.api.walkpost.dto.WalkPostListResponse;
 import kr.co.mongmate.domain.profile.entity.GuardianProfile;
 import kr.co.mongmate.domain.profile.repository.GuardianProfileRepository;
 import kr.co.mongmate.domain.walkpost.entity.WalkPost;
+import kr.co.mongmate.domain.walkpost.entity.WalkPostPhoto;
+import kr.co.mongmate.domain.walkpost.repository.WalkPostPhotoRepository;
 import kr.co.mongmate.domain.walkpost.repository.WalkPostRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -12,6 +14,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.util.Collection;
@@ -29,7 +32,9 @@ public class WalkPostListService {
 
     private final WalkPostRepository walkPostRepository;
     private final GuardianProfileRepository guardianProfileRepository;
+    private final WalkPostPhotoRepository walkPostPhotoRepository;
 
+    @Transactional(readOnly = true)
     public WalkPostListResponse list(
             Integer page,
             Integer size,
@@ -56,9 +61,10 @@ public class WalkPostListService {
         Page<WalkPost> pageResult = walkPostRepository.findAllWithAuthor(regionId, statusFilter, pageable);
 
         Map<Long, String> nicknameByUserId = loadNicknames(pageResult.getContent());
+        Map<Long, String> firstPhotoByPostId = loadFirstPhotos(pageResult.getContent());
 
         List<WalkPostListResponse.Item> items = pageResult.getContent().stream()
-                .map(post -> toItem(post, nicknameByUserId))
+                .map(post -> toItem(post, nicknameByUserId, firstPhotoByPostId))
                 .toList();
 
         WalkPostListResponse.PageInfo pageInfo = new WalkPostListResponse.PageInfo(
@@ -117,7 +123,11 @@ public class WalkPostListService {
                 .collect(Collectors.toMap(GuardianProfile::getUserId, GuardianProfile::getNickname));
     }
 
-    private WalkPostListResponse.Item toItem(WalkPost post, Map<Long, String> nicknameByUserId) {
+    private WalkPostListResponse.Item toItem(
+            WalkPost post,
+            Map<Long, String> nicknameByUserId,
+            Map<Long, String> firstPhotoByPostId
+    ) {
         Long authorId = post.getAuthor() != null ? post.getAuthor().getId() : null;
         String nickname = nicknameByUserId.get(authorId);
         if (nickname == null || nickname.isBlank()) {
@@ -132,12 +142,36 @@ public class WalkPostListService {
                 post.getId(),
                 "WALK",
                 post.getTitle(),
+                firstPhotoByPostId.get(post.getId()),
                 region,
                 post.getDeadlineAt(),
                 nickname,
                 status,
                 post.getCreatedAt()
         );
+    }
+
+    private Map<Long, String> loadFirstPhotos(Collection<WalkPost> posts) {
+        List<Long> postIds = posts.stream()
+                .map(WalkPost::getId)
+                .filter(id -> id != null)
+                .distinct()
+                .toList();
+        if (postIds.isEmpty()) {
+            return Map.of();
+        }
+        List<WalkPostPhoto> photos = walkPostPhotoRepository
+                .findAllByWalkPostIdInOrderByWalkPostIdAscSortOrderAsc(postIds);
+
+        Map<Long, String> firstPhotoByPostId = new java.util.HashMap<>();
+        for (WalkPostPhoto photo : photos) {
+            Long postId = photo.getWalkPost() != null ? photo.getWalkPost().getId() : null;
+            if (postId == null) {
+                continue;
+            }
+            firstPhotoByPostId.putIfAbsent(postId, photo.getPhotoUrl());
+        }
+        return firstPhotoByPostId;
     }
 
     private ResponseStatusException badRequest(String reason) {

--- a/backend/src/main/java/kr/co/mongmate/domain/walkpost/repository/WalkPostPhotoRepository.java
+++ b/backend/src/main/java/kr/co/mongmate/domain/walkpost/repository/WalkPostPhotoRepository.java
@@ -1,0 +1,13 @@
+package kr.co.mongmate.domain.walkpost.repository;
+
+import java.util.Collection;
+import java.util.List;
+import kr.co.mongmate.domain.walkpost.entity.WalkPostPhoto;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface WalkPostPhotoRepository extends JpaRepository<WalkPostPhoto, Long> {
+
+    List<WalkPostPhoto> findAllByWalkPostIdInOrderByWalkPostIdAscSortOrderAsc(Collection<Long> postIds);
+
+    List<WalkPostPhoto> findAllByWalkPostIdOrderBySortOrderAsc(Long postId);
+}

--- a/frontend/src/api/walkPosts.ts
+++ b/frontend/src/api/walkPosts.ts
@@ -7,6 +7,7 @@ export type WalkPostListItem = {
   postId: number;
   recruitType: WalkRecruitType;
   title: string;
+  photoUrl?: string | null;
   region: { regionId: number; displayName: string | null } | null;
   deadlineAt: string | null;
   authorNickname: string;
@@ -30,6 +31,7 @@ export type WalkPostDetailResponse = {
   recruitType?: WalkRecruitType;
   title: string;
   content?: string | null;
+  photoUrls?: string[] | null;
   region?: { regionId: number; displayName: string | null } | null;
   deadlineAt?: string | null;
   authorNickname?: string;

--- a/frontend/src/navigation/RootNavigator.tsx
+++ b/frontend/src/navigation/RootNavigator.tsx
@@ -19,6 +19,9 @@ import EditMyProfileScreen from "../screens/my/EditMyProfileScreen";
 import DogManageScreen from "../screens/my/DogManageScreen";
 import DogEditScreen from "../screens/my/DogEditScreen";
 
+import GuardianProfileSetupScreen from "../screens/auth/GuardianProfileSetupScreen";
+import DogProfileSetupScreen from "../screens/auth/DogProfileSetupScreen";
+
 import { useAuthStore } from "../store/auth";
 
 export type RootStackParamList = {
@@ -29,6 +32,8 @@ export type RootStackParamList = {
   EditMyProfile: undefined;
   DogManage: undefined;
   DogEdit: { mode: "create" } | { mode: "edit"; dogId: number };
+  GuardianProfileSetup: undefined;
+  DogProfileSetup: undefined;
 
   AuthStart: undefined;
   SignupInfo: undefined;
@@ -59,6 +64,7 @@ const theme = {
 export default function RootNavigator() {
   const hydrated = useAuthStore((s) => s.hydrated);
   const isAuthed = useAuthStore((s) => s.isAuthed);
+  const isNewUser = useAuthStore((s) => s.isNewUser);
 
   if (!hydrated) return null;
 
@@ -77,18 +83,25 @@ export default function RootNavigator() {
           }}
         >
           {isAuthed ? (
-            <>
-              <Stack.Screen name="Main" component={MainTabs} />
-              <Stack.Screen name="CreatePost" component={CreatePostScreen} />
-              <Stack.Screen name="PostDetail" component={PostDetailScreen} />
+            isNewUser ? (
+              <>
+                <Stack.Screen name="GuardianProfileSetup" component={GuardianProfileSetupScreen} />
+                <Stack.Screen name="DogProfileSetup" component={DogProfileSetupScreen} />
+              </>
+            ) : (
+              <>
+                <Stack.Screen name="Main" component={MainTabs} />
+                <Stack.Screen name="CreatePost" component={CreatePostScreen} />
+                <Stack.Screen name="PostDetail" component={PostDetailScreen} />
 
-              <Stack.Screen
-                name="EditMyProfile"
-                component={EditMyProfileScreen}
-              />
-              <Stack.Screen name="DogManage" component={DogManageScreen} />
-              <Stack.Screen name="DogEdit" component={DogEditScreen} />
-            </>
+                <Stack.Screen
+                  name="EditMyProfile"
+                  component={EditMyProfileScreen}
+                />
+                <Stack.Screen name="DogManage" component={DogManageScreen} />
+                <Stack.Screen name="DogEdit" component={DogEditScreen} />
+              </>
+            )
           ) : (
             <>
               <Stack.Screen name="AuthStart" component={AuthStartScreen} />

--- a/frontend/src/screens/auth/AuthOtpScreen.tsx
+++ b/frontend/src/screens/auth/AuthOtpScreen.tsx
@@ -161,9 +161,8 @@ export default function AuthOtpScreen() {
           phoneNumber: cleanPhone,
           accessToken: res.accessToken,
           refreshToken: res.refreshToken,
-        });
+        }, true); // ✅ isNewUser = true
 
-        navigation.navigate("Main");
         return;
       }
 

--- a/frontend/src/screens/auth/DogProfileSetupScreen.tsx
+++ b/frontend/src/screens/auth/DogProfileSetupScreen.tsx
@@ -1,0 +1,195 @@
+import React, { useState } from "react";
+import {
+  View,
+  Text,
+  TextInput,
+  StyleSheet,
+  ActivityIndicator,
+  Alert,
+  TouchableOpacity,
+  KeyboardAvoidingView,
+  Platform,
+  ScrollView,
+} from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { useNavigation } from "@react-navigation/native";
+import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
+import type { RootStackParamList } from "../../navigation/RootNavigator";
+import TopHeader from "../../components/TopHeader";
+import AnimatedButton from "../../components/AnimatedButton";
+import { COLORS, SIZES, SHADOWS } from "../../constants/theme";
+import { createDog } from "../../api/profile";
+import { useAuthStore } from "../../store/auth";
+
+type Nav = NativeStackNavigationProp<RootStackParamList, "DogProfileSetup">;
+
+export default function DogProfileSetupScreen() {
+  const navigation = useNavigation<Nav>();
+  const setNewUser = useAuthStore((s) => s.setNewUser);
+
+  const [name, setName] = useState("");
+  const [breed, setBreed] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  const finishSetup = () => {
+    // ✅ AuthStore의 isNewUser를 false로 변경하면 RootNavigator가 알아서 Main으로 전환
+    setNewUser(false);
+  };
+
+  const handleSkip = () => {
+    finishSetup();
+  };
+
+  const handleSubmit = async () => {
+    const trimmedName = name.trim();
+    if (!trimmedName) {
+      Alert.alert("알림", "강아지 이름을 입력해주세요.");
+      return;
+    }
+
+    try {
+      setLoading(true);
+      await createDog({
+        name: trimmedName,
+        breed: breed.trim() || undefined,
+      });
+      // 완료 시 메인 탭으로
+      finishSetup();
+    } catch (e: any) {
+      Alert.alert("오류", e.message ?? "강아지 프로필 저장 중 문제가 발생했습니다.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const canProceed = name.trim().length > 0;
+
+  return (
+    <SafeAreaView style={{ flex: 1, backgroundColor: "#F9FAFB" }}>
+      <TopHeader title="강아지 프로필" />
+
+      <KeyboardAvoidingView
+        style={{ flex: 1 }}
+        behavior={Platform.OS === "ios" ? "padding" : undefined}
+      >
+        <ScrollView contentContainerStyle={styles.container}>
+          <Text style={styles.title}>
+            함께할 반려견을 등록해주세요! 🐶
+          </Text>
+          <Text style={styles.subtitle}>
+            아직 강아지가 없거나, 나중에 등록하시려면 건너뛰기를 눌러주세요.
+          </Text>
+
+          <View style={styles.inputContainer}>
+            <Text style={styles.label}>강아지 이름 (필수)</Text>
+            <TextInput
+              style={styles.input}
+              value={name}
+              onChangeText={setName}
+              placeholder="예: 몽이"
+              maxLength={20}
+            />
+          </View>
+
+          <View style={styles.inputContainer}>
+            <Text style={styles.label}>견종 (선택)</Text>
+            <TextInput
+              style={styles.input}
+              value={breed}
+              onChangeText={setBreed}
+              placeholder="예: 말티즈, 리트리버"
+              maxLength={30}
+            />
+          </View>
+
+          <View style={{ flex: 1 }} />
+
+          <TouchableOpacity style={styles.skipButton} onPress={handleSkip} activeOpacity={0.7}>
+            <Text style={styles.skipText}>나중에 하기 (건너뛰기)</Text>
+          </TouchableOpacity>
+
+          <AnimatedButton
+            style={[
+              styles.nextButton,
+              !canProceed && styles.nextButtonDisabled,
+            ]}
+            disabled={!canProceed || loading}
+            activeOpacity={0.9}
+            onPress={handleSubmit}
+          >
+            {loading ? (
+              <ActivityIndicator color={COLORS.white} />
+            ) : (
+              <Text style={styles.nextText}>완료 및 시작하기</Text>
+            )}
+          </AnimatedButton>
+        </ScrollView>
+      </KeyboardAvoidingView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flexGrow: 1, padding: 24, paddingBottom: 40 },
+  title: {
+    fontSize: 22,
+    fontWeight: "700",
+    color: COLORS.textMain,
+    marginBottom: 8,
+    marginTop: 10,
+  },
+  subtitle: {
+    fontSize: 14,
+    color: COLORS.textSub,
+    marginBottom: 32,
+    lineHeight: 20,
+  },
+  inputContainer: {
+    marginBottom: 20,
+  },
+  label: {
+    fontSize: 14,
+    fontWeight: "600",
+    color: COLORS.textSub,
+    marginBottom: 8,
+  },
+  input: {
+    borderRadius: SIZES.radius.md,
+    borderWidth: 1,
+    borderColor: COLORS.border,
+    backgroundColor: COLORS.white,
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+    fontSize: 16,
+    color: COLORS.textMain,
+    ...SHADOWS.soft,
+  },
+  skipButton: {
+    paddingVertical: 16,
+    alignItems: "center",
+  },
+  skipText: {
+    color: COLORS.textSub,
+    fontSize: 15,
+    fontWeight: "600",
+    textDecorationLine: "underline",
+  },
+  nextButton: {
+    height: 56,
+    borderRadius: SIZES.radius.xl,
+    backgroundColor: COLORS.primary,
+    alignItems: "center",
+    justifyContent: "center",
+    ...SHADOWS.medium,
+  },
+  nextButtonDisabled: {
+    backgroundColor: COLORS.textMuted,
+    shadowOpacity: 0,
+    elevation: 0,
+  },
+  nextText: {
+    color: COLORS.white,
+    fontSize: 18,
+    fontWeight: "700",
+  },
+});

--- a/frontend/src/screens/auth/GuardianProfileSetupScreen.tsx
+++ b/frontend/src/screens/auth/GuardianProfileSetupScreen.tsx
@@ -1,0 +1,197 @@
+import React, { useState, useEffect } from "react";
+import {
+  View,
+  Text,
+  TextInput,
+  StyleSheet,
+  ActivityIndicator,
+  Alert,
+} from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { useNavigation } from "@react-navigation/native";
+import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
+import type { RootStackParamList } from "../../navigation/RootNavigator";
+import TopHeader from "../../components/TopHeader";
+import AnimatedButton from "../../components/AnimatedButton";
+import { COLORS, SIZES, SHADOWS } from "../../constants/theme";
+import { upsertProfile } from "../../api/profile";
+
+type Nav = NativeStackNavigationProp<RootStackParamList, "GuardianProfileSetup">;
+
+const ADJECTIVES = [
+  "행복한", "즐거운", "용감한", "활기찬", "멋진", "귀여운", "사랑스러운", "신나는", "다정한", "따뜻한"
+];
+const NOUNS = [
+  "보호자", "집사", "주인님", "산책러", "가디언", "친구", "동반자", "탐험가", "메이트", "견주님"
+];
+
+function generateRandomNickname() {
+  const adj = ADJECTIVES[Math.floor(Math.random() * ADJECTIVES.length)];
+  const noun = NOUNS[Math.floor(Math.random() * NOUNS.length)];
+  const num = Math.floor(Math.random() * 900) + 100; // 100 ~ 999
+  return `${adj}_${noun}_${num}`;
+}
+
+export default function GuardianProfileSetupScreen() {
+  const navigation = useNavigation<Nav>();
+  const [nickname, setNickname] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    // 진입 시 자동 랜덤 닉네임 부여
+    setNickname(generateRandomNickname());
+  }, []);
+
+  const handleRandomize = () => {
+    setNickname(generateRandomNickname());
+  };
+
+  const handleNext = async () => {
+    const trimmed = nickname.trim();
+    if (!trimmed) {
+      Alert.alert("알림", "닉네임을 입력해주세요.");
+      return;
+    }
+    if (trimmed.length > 30) {
+      Alert.alert("알림", "닉네임은 30자를 초과할 수 없습니다.");
+      return;
+    }
+
+    try {
+      setLoading(true);
+      // 백엔드 API 호출로 보호자 프로필 생성 (존재 시 업데이트)
+      await upsertProfile({
+        guardian: { nickname: trimmed }
+      });
+      // 완료되면 강아지 프로필 설정 창으로 이동
+      navigation.navigate("DogProfileSetup");
+    } catch (e: any) {
+      Alert.alert("오류", e.message ?? "프로필 저장 중 문제가 발생했습니다.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const canProceed = nickname.trim().length > 0;
+
+  return (
+    <SafeAreaView style={{ flex: 1, backgroundColor: "#F9FAFB" }}>
+      <TopHeader title="가디언즈 프로필" />
+
+      <View style={styles.container}>
+        <Text style={styles.title}>
+          활동하실 닉네임을 설정해주세요!
+        </Text>
+        <Text style={styles.subtitle}>
+          언제든지 마이페이지에서 수정할 수 있습니다.
+        </Text>
+
+        <View style={styles.inputContainer}>
+          <Text style={styles.label}>닉네임 (최대 30자)</Text>
+          <TextInput
+            style={styles.input}
+            value={nickname}
+            onChangeText={setNickname}
+            placeholder="닉네임을 입력하세요"
+            maxLength={30}
+          />
+        </View>
+
+        <AnimatedButton
+          style={styles.randomButton}
+          activeOpacity={0.8}
+          onPress={handleRandomize}
+        >
+          <Text style={styles.randomButtonText}>🎲 랜덤 닉네임 생성</Text>
+        </AnimatedButton>
+
+        <View style={{ flex: 1 }} />
+
+        <AnimatedButton
+          style={[
+            styles.nextButton,
+            !canProceed && styles.nextButtonDisabled,
+          ]}
+          disabled={!canProceed || loading}
+          activeOpacity={0.9}
+          onPress={handleNext}
+        >
+          {loading ? (
+            <ActivityIndicator color={COLORS.white} />
+          ) : (
+            <Text style={styles.nextText}>다음</Text>
+          )}
+        </AnimatedButton>
+      </View>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, padding: 24 },
+  title: {
+    fontSize: 22,
+    fontWeight: "700",
+    color: COLORS.textMain,
+    marginBottom: 8,
+    marginTop: 10,
+  },
+  subtitle: {
+    fontSize: 14,
+    color: COLORS.textSub,
+    marginBottom: 32,
+  },
+  inputContainer: {
+    marginBottom: 16,
+  },
+  label: {
+    fontSize: 14,
+    fontWeight: "600",
+    color: COLORS.textSub,
+    marginBottom: 8,
+  },
+  input: {
+    borderRadius: SIZES.radius.md,
+    borderWidth: 1,
+    borderColor: COLORS.border,
+    backgroundColor: COLORS.white,
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+    fontSize: 16,
+    color: COLORS.textMain,
+    ...SHADOWS.soft,
+  },
+  randomButton: {
+    backgroundColor: COLORS.card,
+    borderRadius: SIZES.radius.md,
+    paddingVertical: 12,
+    alignItems: "center",
+    borderWidth: 1,
+    borderColor: COLORS.border,
+    ...SHADOWS.soft,
+  },
+  randomButtonText: {
+    fontSize: 15,
+    fontWeight: "600",
+    color: COLORS.textMain,
+  },
+  nextButton: {
+    height: 56,
+    borderRadius: SIZES.radius.xl,
+    backgroundColor: COLORS.primary,
+    alignItems: "center",
+    justifyContent: "center",
+    ...SHADOWS.medium,
+    marginBottom: 16,
+  },
+  nextButtonDisabled: {
+    backgroundColor: COLORS.textMuted,
+    shadowOpacity: 0,
+    elevation: 0,
+  },
+  nextText: {
+    color: COLORS.white,
+    fontSize: 18,
+    fontWeight: "700",
+  },
+});

--- a/frontend/src/screens/community/CommunityScreen.tsx
+++ b/frontend/src/screens/community/CommunityScreen.tsx
@@ -7,6 +7,7 @@ import {
   RefreshControl,
   NativeSyntheticEvent,
   NativeScrollEvent,
+  Image,
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import {
@@ -33,6 +34,7 @@ type Item = {
   authorNickname: string;
   createdAt: string;
   deadlineText: string;
+  photoUrl?: string | null;
 };
 
 function inferTypeAndTitle(
@@ -80,6 +82,7 @@ export default function CommunityScreen() {
             id: String(it.postId),
             type: fixed.type,
             title: fixed.title,
+            photoUrl: it.photoUrl ?? null,
             region:
               it.region?.displayName ??
               (it.region?.regionId
@@ -203,6 +206,9 @@ export default function CommunityScreen() {
         activeOpacity={0.9}
         onPress={() => navigation.navigate("PostDetail", { postId: item.id })}
       >
+        {item.photoUrl ? (
+          <Image source={{ uri: item.photoUrl }} style={styles.cardImage} />
+        ) : null}
         <View style={styles.cardTop}>
           <View
             style={[
@@ -352,10 +358,18 @@ const styles = StyleSheet.create({
   card: {
     backgroundColor: "#fff",
     borderRadius: 18,
+    overflow: "hidden",
     padding: 16,
     borderWidth: 1,
     borderColor: "#E5E7EB",
     ...SHADOWS.soft,
+  },
+  cardImage: {
+    width: "100%",
+    height: 160,
+    borderRadius: 14,
+    marginBottom: 12,
+    backgroundColor: "#F3F4F6",
   },
   cardTop: {
     flexDirection: "row",

--- a/frontend/src/screens/home/PostDetailScreen.tsx
+++ b/frontend/src/screens/home/PostDetailScreen.tsx
@@ -8,6 +8,7 @@ import {
   Dimensions,
   ActivityIndicator,
   Alert,
+  Image,
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useNavigation, useRoute, RouteProp } from "@react-navigation/native";
@@ -107,6 +108,7 @@ export default function PostDetailScreen() {
       detail?.createdAt ?? post?.createdAt ?? new Date().toISOString();
     const status = post?.status ?? detail?.status ?? "OPEN";
     const placeName = detail?.meetAddress ?? post?.placeName ?? region;
+    const photoUrls = detail?.photoUrls ?? [];
 
     // 타입: store가 제일 정확(우리는 prefix로 보정함)
     const type = post?.type ?? "WALK";
@@ -121,6 +123,7 @@ export default function PostDetailScreen() {
       status,
       placeName,
       type,
+      photoUrls,
     };
   }, [post, detail]);
 
@@ -225,6 +228,23 @@ export default function PostDetailScreen() {
           <View style={{ paddingVertical: 10 }}>
             <ActivityIndicator />
           </View>
+        )}
+
+        {merged.photoUrls.length > 0 && (
+          <ScrollView
+            horizontal
+            showsHorizontalScrollIndicator={false}
+            style={styles.photoStrip}
+            contentContainerStyle={{ gap: 12, paddingRight: 20 }}
+          >
+            {merged.photoUrls.map((url, idx) => (
+              <Image
+                key={`${url}-${idx}`}
+                source={{ uri: url }}
+                style={styles.photo}
+              />
+            ))}
+          </ScrollView>
         )}
 
         <View
@@ -336,6 +356,15 @@ const styles = StyleSheet.create({
   },
   shareButton: { padding: 4 },
   scrollContent: { padding: 20 },
+  photoStrip: {
+    marginBottom: 14,
+  },
+  photo: {
+    width: SCREEN_WIDTH - 60,
+    height: 220,
+    borderRadius: 16,
+    backgroundColor: "#F3F4F6",
+  },
 
   typeBadge: {
     alignSelf: "flex-start",
@@ -434,4 +463,3 @@ const styles = StyleSheet.create({
   },
   errorText: { fontSize: 16, fontWeight: "800", color: "#111827" },
 });
-

--- a/frontend/src/store/auth.ts
+++ b/frontend/src/store/auth.ts
@@ -21,6 +21,7 @@ export type Session = {
 export type AuthState = {
   hydrated: boolean;
   isAuthed: boolean;
+  isNewUser: boolean;
 
   userId: number | null;
   phoneNumber: string | null;
@@ -31,7 +32,8 @@ export type AuthState = {
 
   init: () => Promise<void>;
   setTokens: (accessToken: string, refreshToken?: string) => Promise<void>;
-  setSession: (session: Session) => Promise<void>;
+  setSession: (session: Session, isNewUser?: boolean) => Promise<void>;
+  setNewUser: (isNew: boolean) => void;
   login: (phoneNumber: string) => Promise<"login">;
   logout: () => Promise<void>;
 };
@@ -48,6 +50,7 @@ function sanitizeToken(t: any): string | null {
 export const useAuthStore = create<AuthState>((set, get) => ({
   hydrated: false,
   isAuthed: false,
+  isNewUser: false,
 
   userId: null,
   phoneNumber: null,
@@ -121,7 +124,7 @@ export const useAuthStore = create<AuthState>((set, get) => ({
     }
   },
 
-  setSession: async (session: Session) => {
+  setSession: async (session: Session, isNewUser = false) => {
     await get().setTokens(session.accessToken, session.refreshToken);
 
     if (session.userId != null)
@@ -133,8 +136,11 @@ export const useAuthStore = create<AuthState>((set, get) => ({
       userId: session.userId ?? get().userId,
       phoneNumber: session.phoneNumber ?? get().phoneNumber,
       user: session.me ?? get().user,
+      isNewUser: isNewUser,
     });
   },
+
+  setNewUser: (isNew: boolean) => set({ isNewUser: isNew }),
 
   login: async (phoneNumber: string) => {
     const res = await loginApi(phoneNumber);
@@ -168,6 +174,7 @@ export const useAuthStore = create<AuthState>((set, get) => ({
     console.log("🔒 Resetting store state...");
     set({
       isAuthed: false,
+      isNewUser: false,
       accessToken: null,
       refreshToken: null,
       userId: null,


### PR DESCRIPTION
### [주요 변경]

- 산책글 사진 데이터 리스트/상세 API에 포함함
- 프론트 리스트/상세에서 이미지 렌더링 추가함
- 신규 사용자 프로필 설정 플로우(가디언→강아지) 화면/네비 분기 추가함
- 로그인 이후 STOMP 재연결/토큰 처리 흐름 개선함

----

백엔드
- WalkPostPhotoRepository 추가함
- WalkPostListService, WalkPostDetailService에 사진 조회 로직 추가함
- 리스트 응답에 photoUrl, 상세 응답에 photoUrls 포함함

프론트
- walkPosts API 타입 확장함
- 커뮤니티 리스트 카드 썸네일 표시함
- 상세 화면 이미지 스트립 표시함
- 신규 사용자 온보딩 프로필 화면 추가 및 네비 분기 적용함

영향
- 산책 리스트/상세에서 이미지 표시 가능함
- 신규 가입자 프로필 설정 플로우 활성화됨